### PR TITLE
Remove prop-types in production build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,6 +13,11 @@
       "plugins": [
         "transform-es2015-modules-commonjs"
       ]
+    },
+    "production": {
+      "plugins": [
+        "transform-react-remove-prop-types"
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-jest": "^19.0.0",
     "babel-loader": "^6.4.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.3.3",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-es2017": "^6.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -653,6 +653,10 @@ babel-plugin-transform-react-jsx@^6.23.0:
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-react-remove-prop-types@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.3.3.tgz#d09f48b9a9503a69c1ced39b3825c2f45d29333c"
+
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz#65740593a319c44522157538d690b84094617ea6"


### PR DESCRIPTION
* Uses `transform-react-remove-prop-types` plugin to remove prop-types

Not sure how much this is useful for a small application. Could be important for large applications.